### PR TITLE
Fix JSX bug and reading config file bugs

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -1,33 +1,8 @@
 package main
 
 import (
-	"encoding/json"
-	"os"
-
 	"github.com/urfave/cli/v2"
 )
-
-var globalConfig ConfigJSON
-var hasConfig bool
-var saveConfig bool
-
-func loadConfigFromFile() {
-
-	configJson, err := os.ReadFile(DEPCHECK_DIR + "/config.json")
-
-	if err != nil {
-		return
-	}
-
-	globalConfig = ConfigJSON{}
-
-	err = json.Unmarshal(configJson, &globalConfig)
-
-	if err != nil {
-		return
-	}
-	hasConfig = true
-}
 
 func createCliApp() cli.App {
 	configCommands := setupConfigCLI()
@@ -93,7 +68,6 @@ func createCliApp() cli.App {
 			Name:        "log",
 			Aliases:     []string{"l"},
 			Usage:       "Will write logs to .depcheck.log",
-			Value:       false,
 			Destination: &globalConfig.Log,
 		},
 		&cli.StringFlag{
@@ -106,21 +80,18 @@ func createCliApp() cli.App {
 			Name:        "report",
 			Aliases:     []string{"r"},
 			Usage:       "Generate report file",
-			Value:       false,
 			Destination: &globalConfig.Report,
 		},
 		&cli.BoolFlag{
 			Name:        "show-versions",
 			Aliases:     []string{"v"},
 			Usage:       "Show conflicting versions",
-			Value:       false,
 			Destination: &globalConfig.Versions,
 		},
 		&cli.BoolFlag{
 			Name:        "write-output-files",
 			Aliases:     []string{"w"},
 			Usage:       "This will write the esbuild output files.",
-			Value:       false,
 			Destination: &esbuildWrite,
 		},
 		&cli.StringSliceFlag{
@@ -139,14 +110,12 @@ func createCliApp() cli.App {
 			Name:        "no-open",
 			Aliases:     []string{"no"},
 			Usage:       "Flag to prevent auto opening report in browser",
-			Value:       false,
 			Destination: &noOpen,
 		},
 		&cli.BoolFlag{
 			Name:        "save-config",
 			Aliases:     []string{"sc"},
 			Usage:       "Flag to automatically save config from other flags",
-			Value:       false,
 			Destination: &saveConfig,
 		},
 		&cli.BoolFlag{
@@ -162,25 +131,32 @@ func createCliApp() cli.App {
 		&cli.BoolFlag{
 			Name:        "browser",
 			Usage:       "Will use esbuild browser platform (by default it uses node platform)",
-			Value:       false,
 			Destination: &globalConfig.BrowserPlatform,
 		},
+		&cli.StringSliceFlag{
+			Name:        "ignore-path",
+			Aliases:     []string{"ip"},
+			Usage:       "A glob pattern of files to be ignored",
+			Destination: &ignorePaths,
+		},
 	}
-
-	loadConfigFromFile()
 
 	app := &cli.App{
 		Name:                 "depp",
 		EnableBashCompletion: true,
 		Usage:                "Find un used packages fast",
 		Flags:                flags,
+		// Before:               altsrc.InitInputSourceWithContext(flags, ),
 		Action: func(c *cli.Context) error {
+			loadConfigFromFile()
 
 			depcheck()
+
 			return nil
 		},
 		Commands: commands,
 	}
 
 	return *app
+
 }

--- a/config.go
+++ b/config.go
@@ -12,19 +12,6 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-func getExternals() []string {
-	defaultExternals := []string{}
-
-	cliExternals := externals.Value()
-
-	if len(cliExternals) > 0 {
-		fmt.Println("Cli externals", externals.Value())
-		defaultExternals = append(defaultExternals, cliExternals...)
-	}
-
-	return defaultExternals
-}
-
 type ConfigJSON struct {
 	JS                bool     `json:"js"`
 	Path              string   `json:"path"`
@@ -34,7 +21,79 @@ type ConfigJSON struct {
 	DevDependencies   bool     `json:"dev"`
 	Externals         []string `json:"externals"`
 	IgnoredNamespaces []string `json:"ignore-namespaces"`
+	IgnoredPaths      []string `json:"ignored-paths"`
 	BrowserPlatform   bool     `json:"browser-platform"`
+}
+
+var esbuildWrite bool
+var noOpen bool
+
+var externals cli.StringSlice
+var ignoreNameSpaces cli.StringSlice
+var ignorePaths cli.StringSlice
+
+var globalConfig ConfigJSON
+var hasConfig bool
+var saveConfig bool
+
+func loadConfigFromFile() {
+
+	configJson, err := os.ReadFile(DEPCHECK_DIR + "/config.json")
+
+	if err != nil {
+		return
+	}
+
+	config := ConfigJSON{}
+
+	err = json.Unmarshal(configJson, &config)
+
+	if err != nil {
+		return
+	}
+
+	// Could not think of a better way to this should ask @zackradisic how it should be done
+	// The following if states sets the precedence for flags and the config file
+	// How it works
+	// If flag is set --dev (true) then that will overwrite config value
+	// However if flag is unset the value will be take from config file
+
+	if !globalConfig.BrowserPlatform {
+		globalConfig.BrowserPlatform = config.BrowserPlatform
+	}
+
+	if !globalConfig.DevDependencies {
+		globalConfig.DevDependencies = config.DevDependencies
+	}
+
+	if !globalConfig.JS {
+		globalConfig.JS = config.JS
+	}
+
+	if !globalConfig.Log {
+		globalConfig.Log = config.Log
+	}
+
+	if !globalConfig.Report {
+		globalConfig.Report = config.Report
+	}
+
+	if !globalConfig.Versions {
+		globalConfig.Versions = config.Versions
+	}
+
+	if globalConfig.Path == "" {
+		globalConfig.Path = config.Path
+	}
+
+	globalConfig.Externals = append(externals.Value(), config.Externals...)
+	globalConfig.IgnoredNamespaces = append(ignoreNameSpaces.Value(), config.IgnoredNamespaces...)
+	globalConfig.IgnoredPaths = append(ignorePaths.Value(), config.IgnoredPaths...)
+
+	hasConfig = true
+
+	fmt.Println("Externals", globalConfig.Externals)
+	fmt.Println("Ignored Paths", globalConfig.IgnoredPaths)
 }
 
 func setupConfig() {

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/fatih/color v1.13.0
 	github.com/go-openapi/runtime v0.21.0
 	github.com/go-openapi/strfmt v0.21.0
-	github.com/gomarkdown/markdown v0.0.0-20210918233619-6c1113f12c4a
 	github.com/google/go-github/v39 v39.2.0
 	github.com/netlify/open-api/v2 v2.5.2
 	github.com/tidwall/gjson v1.11.0
@@ -41,6 +40,7 @@ require (
 	github.com/go-stack/stack v1.8.1 // indirect
 	github.com/golang-jwt/jwt/v4 v4.1.0 // indirect
 	github.com/golang/protobuf v1.4.2 // indirect
+	github.com/gomarkdown/markdown v0.0.0-20210918233619-6c1113f12c4a // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "depp-installer",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": " A fast unused and duplicate dependency checker ",
   "repository": {
     "type": "git",

--- a/results.go
+++ b/results.go
@@ -14,7 +14,7 @@ import (
 )
 
 func checkIgnoredNameSpace(module string) bool {
-	namespaces := ignoreNameSpaces.Value()
+	namespaces := globalConfig.IgnoredNamespaces
 
 	if len(namespaces) > 0 {
 		for _, name := range namespaces {

--- a/utils.go
+++ b/utils.go
@@ -84,6 +84,7 @@ func Glob(pattern string) ([]string, error) {
 		return filepath.Glob(pattern)
 	}
 	ingored := []string{"node_modules", "dist", ".next"}
+	ingored = append(ingored, globalConfig.IgnoredPaths...)
 
 	return handleGlobs(strings.Split(pattern, "**"), ingored)
 }
@@ -109,18 +110,18 @@ func check(err error) {
 func MoveFile(sourcePath, destPath string) error {
 	inputFile, err := os.Open(sourcePath)
 	if err != nil {
-		return fmt.Errorf("Couldn't open source file: %s", err)
+		return fmt.Errorf("couldn't open source file: %s", err)
 	}
 	outputFile, err := os.Create(destPath)
 	if err != nil {
 		inputFile.Close()
-		return fmt.Errorf("Couldn't open dest file: %s", err)
+		return fmt.Errorf("couldn't open dest file: %s", err)
 	}
 	defer outputFile.Close()
 	_, err = io.Copy(outputFile, inputFile)
 	inputFile.Close()
 	if err != nil {
-		return fmt.Errorf("Writing to output file failed: %s", err)
+		return fmt.Errorf("writing to output file failed: %s", err)
 	}
 	// // The copy was successful, so now delete the original file
 	// err = os.Remove(sourcePath)

--- a/writer.go
+++ b/writer.go
@@ -53,9 +53,9 @@ func removeDirectory(noLog bool) {
 func writeLogsToFile() {
 
 	if globalConfig.Log {
-		fmt.Println("Will be logging output to .depcheck.log")
+		fmt.Println("Will be logging output to " + DEPCHECK_DIR + "/debug.log")
 		// open output file
-		fo, err := os.Create(DEPCHECK_DIR + "/.depcheck.log")
+		fo, err := os.Create(DEPCHECK_DIR + "/debug.log")
 		fileOps.Add(1)
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
Resolves #9 

There were a few bugs here, the three main bugs were
- Bad error printing, the error is much easier to understand when printed out properly
- The default loader for `.js` files was not set to `jsx` so could not understand JSX. That is where the `<` comes from
- The global config being overwrite by the default `false` from the flags